### PR TITLE
Updated larger runners docs

### DIFF
--- a/content/actions/using-github-hosted-runners/using-larger-runners.md
+++ b/content/actions/using-github-hosted-runners/using-larger-runners.md
@@ -87,7 +87,7 @@ You can add a {% data variables.actions.hosted_runner %} to an organization, whe
 
 ## Running jobs on your runner
 
-Once your runner type has been been defined, you can update your workflows to send jobs to the runner instances for processing. In this example, a runner group is populated with Ubuntu 16-core runners, which have been assigned the label `ubuntu-20.04-16core`. If you have a runner matching this label, the `check-bats-version` job then uses the `runs-on` key to target that runner whenever the job is run:
+Once your runner type has been defined, you can update your workflow's YAML file to send jobs to your newly created runner instances for processing. In this example, a runner group is populated with Ubuntu 16-core runners, which have been assigned the label `ubuntu-20.04-16core`. If you have a runner matching this label, the `check-bats-version` job then uses the `runs-on` key to target that runner whenever the job is run:
 
 ```yaml
 name: learn-github-actions
@@ -103,6 +103,7 @@ jobs:
       - run: npm install -g bats
       - run: bats -v
 ```
+To find out which runners are enabled for your repository and organization you will need to contact your org admin. Your org admin is able to create new runners and runner groups, as well as configure permissions to specify which repositories can access a runner group.
 
 ## Managing access to your runners
 


### PR DESCRIPTION
Added a section telling users with edit access that they need to request new runners and runner groups from their org admin.

### Why:

We're seeing a bottleneck around new customers in the beta being slow to actually use the Larger Runners they've enabled. A lot of users (with edit access) may not know they have the larger runners available, or how to find the labels for them. We're launching a banner to let these users know they're in the beta for Larger Runners, with a CTA that takes them to this page in the docs. We want to make sure we're clear on how to use the runners for non-admin users.

- https://github.com/github/octogrowth/issues/1229

### What's being changed (if available, include any code snippets, screenshots, or gifs):

**Changes:**
- Fixed a typo saying "been" twice
- Specified "YAML file" after "your workflows"
- Added "newly created" before "runner instances" so they know we're referring to the ones they just made
- Added the last paragraph to point non-org-admins in the right direction to find out what their runner labels are and who to ask for new ones.

### Check off the following:

- [x] I have reviewed my changes in staging
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

